### PR TITLE
fix query selector to make extension work again

### DIFF
--- a/bca-gpa/main.js
+++ b/bca-gpa/main.js
@@ -73,7 +73,7 @@ function classData() {
 	var data = []
 
 	for (var i = 0; i < classes.length; i++) {
-		var name = classes.item(i).querySelector('td[align="left"]');
+		var name = classes.item(i).querySelector('td[class="table-element-text-align-start"]');
 		name = name.textContent;
 		if (name[0] == '~') continue; //Not included in GPA
 


### PR DESCRIPTION
powerschool updated with new styles which messed up the query selectors that worked with the old styles. this fixes that issue